### PR TITLE
Made time-error message clearer

### DIFF
--- a/time_interface.r2py
+++ b/time_interface.r2py
@@ -87,6 +87,11 @@ def time_updatetime(localport):
     None.
   """
   exception_list = []
+  
+  # Raise exception if TIME_IMP_DICT is empty. Otherwise proceed ahead.
+  if not TIME_IMP_DICT:
+    raise TimeError("time_updatetime called with an empty TIME_IMP_DICT. Use time_register_method to populate it!")
+    
   # try the 'update' function for each implementation, storing exceptions in
   # case of total failure, and exiting the function when any of the 'update'
   # functions succeed.


### PR DESCRIPTION
On passing disallowed port numbers, time_interface was displaying misleading error in the form of `raise TimeError("time_updatetime called before time_register_method!")`
Also, there was an unreachable part of code `raise TimeError('Error(s) in time_updatetime: ' + str(exception_list))`, which has been fixed in this PR.
