### PR TITLE
Update ut_seattlelib_ntptime.py

### DIFF
--- a/tests/ut_seattlelib_ntptime.py
+++ b/tests/ut_seattlelib_ntptime.py
@@ -5,15 +5,16 @@
   Function Tested:
     ntp_time_updatetime() in ntp_time.r2py
 """
-    
-from repyportability import *
-add_dy_support(locals())
+#pragma repy restrictions.default dylink.r2py    
+#from repyportability import *
+#add_dy_support(locals())
 
-time_interface = dy_import_module("time.r2py")
+time_interface = dy_import_module("time_interface.r2py")
 ntp_time = dy_import_module("ntp_time.r2py")
-
+timeport = list(getresources()[0]["connport"])[0]
 try:
-  time_interface.time_updatetime(12345)
+  
+  time_interface.time_updatetime(timeport)
 
   time_interface.time_gettime()
 

--- a/tests/ut_seattlelib_ntptime.py
+++ b/tests/ut_seattlelib_ntptime.py
@@ -3,7 +3,9 @@
   Test the ntp_time library which now uses
   Repy V2 network API calls.
   Function Tested:
-  ntp_time_updatetime() in ntp_time.r2py is indirectly tested / called from time_interface.time_updatetime() due to the dy_import_module("ntp_time.r2py") statement which registers the method as ntp
+  ntp_time_updatetime() in ntp_time.r2py is indirectly tested / 
+  called from time_interface.time_updatetime() due to the 
+  dy_import_module("ntp_time.r2py") statement which registers the method as ntp
 """
 #pragma repy restrictions.default dylink.r2py    
 

--- a/tests/ut_seattlelib_ntptime.py
+++ b/tests/ut_seattlelib_ntptime.py
@@ -3,11 +3,9 @@
   Test the ntp_time library which now uses
   Repy V2 network API calls.
   Function Tested:
-    ntp_time_updatetime() in ntp_time.r2py
+  ntp_time_updatetime() in ntp_time.r2py is indirectly tested / called from time_interface.time_updatetime() due to the dy_import_module("ntp_time.r2py") statement which registers the method as ntp
 """
 #pragma repy restrictions.default dylink.r2py    
-#from repyportability import *
-#add_dy_support(locals())
 
 time_interface = dy_import_module("time_interface.r2py")
 ntp_time = dy_import_module("ntp_time.r2py")


### PR DESCRIPTION
Changed time interface from time.r2py to time_interface.r2py and added the line for timeport.