### PR TITLE
Update ut_seattlelib_time_interface_updatetime_before_registermethod.r2p...

### DIFF
--- a/tests/ut_seattlelib_time_interface_updatetime_before_registermethod.r2py
+++ b/tests/ut_seattlelib_time_interface_updatetime_before_registermethod.r2py
@@ -14,4 +14,4 @@ except time_interface.TimeError:
   pass
 else:
   # we have to fail this if we try didnt raise a exception for not registering time method
-  log("[FAIL]: Did not raise exception for not registering time method (ntp/tcp) \n")
+  log("[FAIL]: The call to time_interface.time_updatetime() method has succeeded but instead it should have raised time_interface.TimeError exception.  This exception has to be raised if time_register_method() which registers the (tcp / ntp) method is not called prior to calling time_interface.time_updatetime() method \n")

--- a/tests/ut_seattlelib_time_interface_updatetime_before_registermethod.r2py
+++ b/tests/ut_seattlelib_time_interface_updatetime_before_registermethod.r2py
@@ -13,5 +13,10 @@ except time_interface.TimeError:
   # That's what we expect
   pass
 else:
-  # we have to fail this if we try didnt raise a exception for not registering time method
-  log("[FAIL]: The call to time_interface.time_updatetime() method has succeeded but instead it should have raised time_interface.TimeError exception.  This exception has to be raised if time_register_method() which registers the (tcp / ntp) method is not called prior to calling time_interface.time_updatetime() method \n")
+  # we have to fail this if we try didnt raise a exception 
+  #for not registering time method
+  log("[FAIL]: The call to time_interface.time_updatetime() method "
+  "has succeeded but instead it should have raised time_interface.TimeError "
+  "exception.  This exception has to be raised if time_register_method() which "
+  "registers the (tcp / ntp) method is not called prior to "
+  "calling time_interface.time_updatetime() method \n")

--- a/tests/ut_seattlelib_time_interface_updatetime_before_registermethod.r2py
+++ b/tests/ut_seattlelib_time_interface_updatetime_before_registermethod.r2py
@@ -12,3 +12,6 @@ try:
 except time_interface.TimeError:
   # That's what we expect
   pass
+else:
+  # we have to fail this if we try didnt raise a exception for not registering time method
+  log("[FAIL]: Did not raise exception for not registering time method (ntp/tcp) \n")


### PR DESCRIPTION
...y
create a else block to fail the test if it does not raise exception for not registering time method