### PR TITLE
Changed restrictons.test to restrictons.default

### DIFF
--- a/tests/ut_seattlelib_dylink_catch_nestedimport_exception.r2py
+++ b/tests/ut_seattlelib_dylink_catch_nestedimport_exception.r2py
@@ -2,7 +2,7 @@
 Verify that we can catch an excpetion defined in an imported library 
 and raised in another.
 """
-#pragma repy restrictions.test dylink.r2py
+#pragma repy restrictions.default dylink.r2py
 #pragma out Successfully caught Lib1Error().
 
 # lib1 defines the exception

--- a/tests/ut_seattlelib_dylinkdispatch.r2py
+++ b/tests/ut_seattlelib_dylinkdispatch.r2py
@@ -1,4 +1,4 @@
-#pragma repy restrictions.test dylink.r2py
+#pragma repy restrictions.default dylink.r2py
 #pragma out Complete!
 
 """

--- a/tests/ut_seattlelib_dylinkoverwritesymbols.r2py
+++ b/tests/ut_seattlelib_dylinkoverwritesymbols.r2py
@@ -1,4 +1,4 @@
-#pragma repy restrictions.test dylink.r2py
+#pragma repy restrictions.default dylink.r2py
 
 """
 Testing to see whether symbols are overwritten

--- a/tests/ut_seattlelib_dylinkselfimport.r2py
+++ b/tests/ut_seattlelib_dylinkselfimport.r2py
@@ -1,4 +1,4 @@
-#pragma repy restrictions.test dylink.r2py
+#pragma repy restrictions.default dylink.r2py
 """
 Try to import (via dylink) this very file. Should NOT cause infinite recursion.
 """

--- a/tests/ut_seattlelib_dylinksimple.r2py
+++ b/tests/ut_seattlelib_dylinksimple.r2py
@@ -1,4 +1,4 @@
-#pragma repy restrictions.test dylink.r2py dytestmoduleexitall.r2py
+#pragma repy restrictions.default dylink.r2py dytestmoduleexitall.r2py
 
 """
 Basic dylink tests.   Nothing fancy.


### PR DESCRIPTION
Restrictions.test does not exist in the common repository and the unit tests:
-ut_seattlelib_dylinkdispatch.r2py
-ut_seattlelib_dylinkoverwritesymbols.r2py
-ut_seattlelib_dylinkselfimport.r2py
-ut_seattlelib_dylinksimple.r2py
-ut_seattlelib_dylink_catch_nestedimport_exception.r2py

are not testing anything with specific restrictions
