### PR TITLE
Fix #164, dylink import behavior for names that start with "_"

### DIFF
--- a/dylink.r2py
+++ b/dylink.r2py
@@ -100,8 +100,8 @@ def _dy_bind_code(module, context):
 
     # Check each key, and bind those we should...
     for attr in context:
-      # Skip attributes starting with _ or part of the stock API
-      if attr.startswith("_") or attr in STOCK_API:
+      # Skip attributes that are part of the stock API
+      if attr in STOCK_API:
         continue
 
       # Bind now
@@ -245,7 +245,8 @@ def dylink_import_global(module, module_context,new_callfunc="import"):
     # It is critical to avoid overwriting things like _context, callfunc,
     # and dy_import_module because these are specific to the containing 
     # module
-    if symbolname not in SYMBOLS_TO_IGNORE_WHEN_FROM_X_IMPORT:
+    if (symbolname not in SYMBOLS_TO_IGNORE_WHEN_FROM_X_IMPORT and 
+        not symbolname.startswith("_")):
       module_context[symbolname] = module_object._context[symbolname]
 
 

--- a/tests/examplelib.py
+++ b/tests/examplelib.py
@@ -2,3 +2,4 @@
 Example library used to demonstrate import-override rules.
 """
 foo = "examplelib.py's foo"
+_foo = "examplelib.py's underscore-foo"

--- a/tests/ut_seattlelib_dylinkunderscoreimportmodule.r2py
+++ b/tests/ut_seattlelib_dylinkunderscoreimportmodule.r2py
@@ -1,0 +1,8 @@
+"""
+Verify that `dylink`'s `dy_import_module` makes names with an underscore 
+prefix accessible.
+"""
+#pragma repy restrictions.test dylink.r2py
+examplelib = dy_import_module("examplelib.py")
+
+examplelib._foo

--- a/tests/ut_seattlelib_dylinkunderscoreimportmodulesymbols.r2py
+++ b/tests/ut_seattlelib_dylinkunderscoreimportmodulesymbols.r2py
@@ -1,0 +1,15 @@
+"""
+Verify that `dylink`'s `dy_import_module_symbols` hides names with 
+an underscore prefix from the importer's namespace.
+"""
+#pragma repy restrictions.test dylink.r2py
+dy_import_module_symbols("examplelib.py")
+
+try:
+  _foo
+except NameError:
+  # The expected, correct exception.
+  pass
+else:
+  log("Error! Expected examplelib's `_foo` to be hidden, like in Python!\n")
+

--- a/tests/ut_seattlelib_dylinkunderscorepythonfromximport.py
+++ b/tests/ut_seattlelib_dylinkunderscorepythonfromximport.py
@@ -1,0 +1,14 @@
+"""
+Demonstrate that Python's `from MODULE import *` hides names with 
+an underscore prefix from the importer's namespace.
+"""
+from examplelib import *
+
+try:
+  _foo
+except NameError:
+  # The expected, correct exception.
+  pass
+else:
+  print "Error! Expected examplelib's `_foo` to be hidden!"
+

--- a/tests/ut_seattlelib_dylinkunderscorepythonimport.py
+++ b/tests/ut_seattlelib_dylinkunderscorepythonimport.py
@@ -1,0 +1,7 @@
+"""
+Demonstrate that Python's `import` makes names with an underscore 
+prefix accessible.
+"""
+import examplelib
+examplelib._foo
+


### PR DESCRIPTION
This PR proposes tests to highlight #164, and also a fix that makes `dylink`'s import functions behave like Python's. From the commit message of the ``fix'' part,
> * `dy_import_module_symbols` (akin to Python's `from MODULE import *`)
>  now correctly *skips* names that start with an underscort ("_"), and
>* `dy_import_module` (akin to Python's `import MODULE`) now *does*
>  correctly import these names.