### PR TITLE
Minor change to sshkey_paramiko.r2py. Replaced decode() with decode_next() 

### DIFF
--- a/sshkey_paramiko.r2py
+++ b/sshkey_paramiko.r2py
@@ -83,7 +83,7 @@ class _sshkey_paramiko_BER(object):
     
   <Example Use>
     ber_obj _sshkey_paramiko_BER(data)
-    list = ber_obj.decode()
+    list = ber_obj.decode_next()
     
   """
 
@@ -95,8 +95,8 @@ class _sshkey_paramiko_BER(object):
       self.content = content
       self.idx = 0
 
-  def decode(self):
-      return self.decode_next()
+  # def decode(self):
+  #     return self.decode_next()
   
   def decode_next(self):
     if self.idx >= len(self.content):
@@ -373,7 +373,7 @@ def _sshkey_paramiko_read_private_key(tag, openfile, password=None):
   # private key file contains:                                                                                          
   # keylist = { version = 0, n, e, d, p, q, d mod p-1, d mod q-1, q**-1 mod p }                                   
   try:
-    keylist = _sshkey_paramiko_BER(keydata).decode()
+    keylist = _sshkey_paramiko_BER(keydata).decode_next()
   except sshkey_paramiko_BERException:
     raise sshkey_paramiko_SSHException('Unable to parse key file')
   

--- a/sshkey_paramiko.r2py
+++ b/sshkey_paramiko.r2py
@@ -94,9 +94,6 @@ class _sshkey_paramiko_BER(object):
   def __init__(self, content=''):
       self.content = content
       self.idx = 0
-
-  # def decode(self):
-  #     return self.decode_next()
   
   def decode_next(self):
     if self.idx >= len(self.content):


### PR DESCRIPTION
Replaced the decode() function calls with decode_next(), since decode is not allowed for safety reasons. 

See the relevant repyV1 commit that introduced that safety check:
https://github.com/SeattleTestbed/repy_v1/commit/bc6b6b9e3ad4cf2785766721b92a985cf628df82

Also, the same changes made to sshkey_paramiko.repy: 
https://github.com/SeattleTestbed/seattlelib_v1/commit/2d1262ef8dcd69fc9a69dd11d0639ed96482cf93?diff=unified

