### PR TITLE
Make the `serialize` unit tests runnable again

### DIFF
--- a/tests/ut_seattlelib_serialize_all.r2py
+++ b/tests/ut_seattlelib_serialize_all.r2py
@@ -1,10 +1,9 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
   for stuff in [None, -123, -233.35345234, [], set(), {frozenset([1,2,3]):'here', 1:2, 3:4, 5:6, 9:10, 8:7}, {}, [set(frozenset(((),3, None)))], False, {'this':['asdf',True, {'here':[False]}], frozenset([1,2,3,4]):complex('3245-292834j')}]:
-    serdata1 = serialize_serializedata(stuff)
-    serdata2 = serialize_serializedata(serdata1)
-    newstuff2 = serialize_deserializedata(serdata2)
-    newstuff = serialize_deserializedata(newstuff2)
+    serdata = serialize_serializedata(stuff)
+    newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff, newstuff
+      log("BAD STUFF:", stuff, newstuff, "\n")

--- a/tests/ut_seattlelib_serialize_dict.r2py
+++ b/tests/ut_seattlelib_serialize_dict.r2py
@@ -1,3 +1,4 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
@@ -5,4 +6,4 @@ if callfunc == 'initialize':
     serdata = serialize_serializedata(stuff)
     newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff, newstuff
+      log("BAD STUFF:", stuff, newstuff, "\n")

--- a/tests/ut_seattlelib_serialize_frozenset.r2py
+++ b/tests/ut_seattlelib_serialize_frozenset.r2py
@@ -1,3 +1,4 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
@@ -5,4 +6,4 @@ if callfunc == 'initialize':
     serdata = serialize_serializedata(stuff)
     newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff
+      log("BAD STUFF:", stuff, newstuff, "\n")

--- a/tests/ut_seattlelib_serialize_list.r2py
+++ b/tests/ut_seattlelib_serialize_list.r2py
@@ -1,8 +1,10 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
-  for stuff in [set((1,)), set(), set(('asdf',True, None, 234)), set(((1,2),3,None)), set(())]:
+  for stuff in [[1], [], ['asdf',True, None, 234], [[1,2],[3],None], [[[[[]]]]]]:
     serdata = serialize_serializedata(stuff)
     newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff
+      log("BAD STUFF:", stuff, newstuff, "\n")
+

--- a/tests/ut_seattlelib_serialize_recursive.r2py
+++ b/tests/ut_seattlelib_serialize_recursive.r2py
@@ -1,8 +1,12 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
   for stuff in [None, -123, -233.35345234, [], set(), {frozenset([1,2,3]):'here', 1:2, 3:4, 5:6, 9:10, 8:7}, {}, [set(frozenset(((),3, None)))], False, {'this':['asdf',True, {'here':[False]}], frozenset([1,2,3,4]):complex('3245-292834j')}]:
-    serdata = serialize_serializedata(stuff)
-    newstuff = serialize_deserializedata(serdata)
+    serdata1 = serialize_serializedata(stuff)
+    serdata2 = serialize_serializedata(serdata1)
+    newstuff2 = serialize_deserializedata(serdata2)
+    newstuff = serialize_deserializedata(newstuff2)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff, newstuff
+      log("BAD STUFF:", stuff, newstuff, "\n")
+

--- a/tests/ut_seattlelib_serialize_set.r2py
+++ b/tests/ut_seattlelib_serialize_set.r2py
@@ -1,8 +1,10 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
-  for stuff in [[1], [], ['asdf',True, None, 234], [[1,2],[3],None], [[[[[]]]]]]:
+  for stuff in [set((1,)), set(), set(('asdf',True, None, 234)), set(((1,2),3,None)), set(())]:
     serdata = serialize_serializedata(stuff)
     newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff
+      log("BAD STUFF:", stuff, newstuff, "\n")
+

--- a/tests/ut_seattlelib_serialize_simple.r2py
+++ b/tests/ut_seattlelib_serialize_simple.r2py
@@ -1,3 +1,4 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
@@ -5,4 +6,5 @@ if callfunc == 'initialize':
     serdata = serialize_serializedata(stuff)
     newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff
+      log("BAD STUFF:", stuff, newstuff, "\n")
+

--- a/tests/ut_seattlelib_serialize_tuple.r2py
+++ b/tests/ut_seattlelib_serialize_tuple.r2py
@@ -1,3 +1,4 @@
+#pragma repy restrictions.default dylink.r2py
 dy_import_module_symbols('serialize.r2py')
 
 if callfunc == 'initialize':
@@ -5,4 +6,5 @@ if callfunc == 'initialize':
     serdata = serialize_serializedata(stuff)
     newstuff = serialize_deserializedata(serdata)
     if newstuff != stuff:
-      print "BAD STUFF:",stuff
+      log("BAD STUFF:", stuff, newstuff, "\n")
+


### PR DESCRIPTION
This involves
* renaming them to the `ut_MODULE_TEST` tests naming scheme,
* adding a `#pragma repy`,
* using `dylink`, and
* replacing RepyV1's `print` with RepyV2's `log` throughout.
