### PR TITLE
Bug fix (#195): Handle type check of bool seperately due to conflict with int type

### DIFF
--- a/tests/ut_seattlelib_wrapper_check_args.r2py
+++ b/tests/ut_seattlelib_wrapper_check_args.r2py
@@ -1,0 +1,58 @@
+"""
+Verify that wrapper's _check_func_args handles bool properly
+"""
+#pragma repy restrictions.default dylink.r2py
+wrapper = dy_import_module("wrapper.r2py")
+
+def test_target(arg1):
+    return True
+
+TEST_FUNC_DEF = {
+    "test_func": {
+        "type": "func",
+        "exceptions": Exception, 
+        "return": (bool,), 
+        "target": test_target
+    }
+}
+
+# Case 1: Passing a bool as function argument fails when the args restriction is a list containing an int (and not bool)
+
+TEST_FUNC_DEF["test_func"]["args"] = ((int,),)
+wrapped_ref = wrapper.wrap_references(TEST_FUNC_DEF)
+
+try:
+    wrapped_ref["test_func"](True)
+except RepyArgumentError:
+    pass
+else:
+    log("Call should have raised a RepyArgumentError")
+
+# Case 2: Passing a bool as function argument fails when the args restriction is an int
+TEST_FUNC_DEF["test_func"]["args"] = (int,)
+wrapped_ref = wrapper.wrap_references(TEST_FUNC_DEF)
+
+try:
+    wrapped_ref["test_func"](True)
+except RepyArgumentError:
+    pass
+else:
+    log("Call should have raised a RepyArgumentError")
+
+# Case 3: Passing a bool works in both of the above cases when using a bool type
+TEST_FUNC_DEF["test_func"]["args"] = ((bool,),)
+wrapped_ref = wrapper.wrap_references(TEST_FUNC_DEF)
+wrapped_ref["test_func"](True)
+
+TEST_FUNC_DEF["test_func"]["args"] = (bool,)
+wrapped_ref = wrapper.wrap_references(TEST_FUNC_DEF)
+wrapped_ref["test_func"](True) 
+
+# Case 4: Passing an int behaves normally
+TEST_FUNC_DEF["test_func"]["args"] = ((int,),)
+wrapped_ref = wrapper.wrap_references(TEST_FUNC_DEF)
+wrapped_ref["test_func"](1)
+
+TEST_FUNC_DEF["test_func"]["args"] = (int,)
+wrapped_ref = wrapper.wrap_references(TEST_FUNC_DEF)
+wrapped_ref["test_func"](1) 

--- a/wrapper.r2py
+++ b/wrapper.r2py
@@ -457,7 +457,9 @@ def _check_func_args(name, arg_definition, args):
       if "any" in expected_types:
         match = True
       else:
-        # handling 'bool' seperately
+        # Since bool is a subtype of int in python, trying to restrict arguments passed to a function using int will also include bool, which can lead to unexpected results.
+        # This violates the principle of least astonishment, since users would not expect bool to be included when they restrict argument types with int.
+        # There is also a potential inconsistency in behaviour, as repy library functions use a different type check, that will catch erroneously passed bools.
         if bool not in expected_types and isinstance(args[index], bool):
           match = False
         else:
@@ -465,6 +467,7 @@ def _check_func_args(name, arg_definition, args):
 
     # Only a single type
     else:
+      # the issue with bool being a subtype of int is not applicable here, since bool is int == False 
       match = arg_type is expected_types or expected_types == "any"
 
     # If there is no match, raise an exception

--- a/wrapper.r2py
+++ b/wrapper.r2py
@@ -457,7 +457,11 @@ def _check_func_args(name, arg_definition, args):
       if "any" in expected_types:
         match = True
       else:
-        match = isinstance(args[index], expected_types)
+        # handling 'bool' seperately
+        if bool not in expected_types and isinstance(args[index], bool):
+          match = False
+        else:
+          match = isinstance(args[index], expected_types)
 
     # Only a single type
     else:


### PR DESCRIPTION
In wrapper.r2py line 460, there's a type check to see if arguments passed to a function match the expected types. It uses the isinstance() built-in to do the check. However, since bool is a subtype of int in python, trying to restrict arguments passed to a function using int will also include bool, which can lead to unexpected results.

This violates the principle of least astonishment, since users would not expect bool to be included when they restrict argument types with int.

Also, there is also a potential inconsistency in behaviour, as repy library functions use a different type check, that will catch erroneously passed bools.